### PR TITLE
fix: remove npm from dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "npm"
-    directory: "/docs"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes npm package-ecosystem from dependabot file.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
